### PR TITLE
feat: 手动自拍日程开关、自动自拍 LLM 提示词生成、多项修复与清理

### DIFF
--- a/core/api_clients/__init__.py
+++ b/core/api_clients/__init__.py
@@ -150,6 +150,7 @@ async def generate_image_standalone(
     model_config: Dict[str, Any],
     size: str = "1024x1024",
     negative_prompt: Optional[str] = None,
+    strength: Optional[float] = None,
     input_image_base64: Optional[str] = None,
     max_retries: int = 2,
     extra_config: Optional[Dict[str, Any]] = None,
@@ -163,6 +164,7 @@ async def generate_image_standalone(
         model_config: 模型配置字典，必须包含 base_url, api_key, format, model 等字段
         size: 图片尺寸，默认 "1024x1024"
         negative_prompt: 额外负面提示词，会合并到 model_config 的 negative_prompt_add
+        strength: 图生图强度（0.0-1.0），仅图生图时使用
         input_image_base64: 输入图片的 base64 编码（图生图用）
         max_retries: 最大重试次数
         extra_config: 额外配置（如 proxy 设置），格式同 config.toml 结构
@@ -192,6 +194,7 @@ async def generate_image_standalone(
             prompt=prompt,
             model_config=merged_config,
             size=size,
+            strength=strength,
             input_image_base64=input_image_base64,
             max_retries=max_retries,
         )

--- a/core/api_clients/base_client.py
+++ b/core/api_clients/base_client.py
@@ -7,6 +7,11 @@ from src.common.logger import get_logger
 logger = get_logger("mais_art.api")
 
 
+class NonRetryableError(Exception):
+    """不可重试的错误（如内容审核拒绝），直接终止重试循环"""
+    pass
+
+
 class BaseApiClient:
     """API客户端基类"""
 
@@ -152,6 +157,10 @@ class BaseApiClient:
                 else:
                     logger.error(f"{self.log_prefix} 重试 {max_retries} 次后API调用仍失败: {result}")
                     return False, result
+
+            except NonRetryableError as e:
+                logger.error(f"{self.log_prefix} 不可重试的错误，跳过剩余重试: {e}")
+                return False, str(e)
 
             except Exception as e:
                 if attempt < max_retries:

--- a/core/selfie/caption_generator.py
+++ b/core/selfie/caption_generator.py
@@ -107,6 +107,18 @@ async def generate_caption(
                 logger.warning("LLM 返回配文过短，视为失败")
                 return ""
 
+            # 完整性检查：配文应以标点或表情结尾，否则可能被截断
+            valid_endings = ("。", "！", "？", "~", "～", "…", ")", "）",
+                            "」", "'", '"', "♪", "☆", "♡",
+                            "呢", "哦", "啊", "呀", "吧", "了", "嘛", "哈", "噢", "耶")
+            if len(caption) >= 8 and not caption.endswith(valid_endings):
+                # 尝试截断到最后一个完整句子
+                for punct in ("。", "！", "？", "~", "～", "…"):
+                    last_pos = caption.rfind(punct)
+                    if last_pos > 0:
+                        caption = caption[:last_pos + 1]
+                        break
+
             logger.info(f"LLM 生成配文: {caption}")
             return caption
         else:

--- a/core/selfie/scene_action_generator.py
+++ b/core/selfie/scene_action_generator.py
@@ -1,164 +1,195 @@
 """
-场景动作生成器（精简版）
+场景动作生成器
 
 根据 ActivityInfo 生成符合情境的动作和 Stable Diffusion 提示词。
-从 selfie_painter 的 SceneActionGenerator 精简而来，
-不依赖 ScheduleEntry，使用简化的 ActivityInfo。
+
+自动自拍：优先使用 LLM 根据活动描述生成英文 SD 场景标签，失败时取消。
+手动自拍：使用确定性映射（get_action_for_activity）。
 """
 
-import random
+import json
 import re
 from typing import Dict, List, Optional
 
 from src.common.logger import get_logger
 
-from .schedule_provider import ActivityInfo, ActivityType
+from .schedule_provider import ActivityInfo
 from ..utils import ANTI_DUAL_HANDS_PROMPT
 
 logger = get_logger("auto_selfie.scene")
 
 
-# 活动类型到动作的映射（12 种类型）
-ACTIVITY_ACTIONS: Dict[str, List[str]] = {
-    "sleeping": [
-        "lying down, relaxed",
-        "hugging pillow, cozy",
-        "stretching arms, sleepy",
-        "curled up in bed",
-        "peaceful sleeping pose",
-    ],
-    "waking_up": [
-        "stretching, yawning",
-        "rubbing eyes, sleepy",
-        "sitting on bed edge",
-        "messy hair, just woke up",
-        "holding alarm clock",
-    ],
-    "eating": [
-        "holding chopsticks, eating",
-        "holding cup, drinking",
-        "picking up food",
-        "holding fork and knife",
-        "holding spoon, tasting",
-        "holding bowl, eating",
-    ],
-    "working": [
-        "typing on laptop",
-        "writing notes",
-        "looking at screen, focused",
-        "holding pen, thinking",
-        "reading documents",
-    ],
-    "studying": [
-        "holding book, reading",
-        "writing in notebook",
-        "looking at textbook",
-        "holding pen, studying",
-        "taking notes",
-    ],
-    "exercising": [
-        "stretching, athletic",
-        "holding water bottle",
-        "wiping sweat, tired",
-        "doing yoga pose",
-        "running pose",
-    ],
-    "relaxing": [
-        "lying on couch, relaxed",
-        "resting head on hand, zoning out",
-        "reading magazine",
-        "listening to music, headphones",
-        "watching TV, relaxed",
-    ],
-    "socializing": [
-        "waving hand, greeting",
-        "making peace sign, happy",
-        "laughing, joyful",
-        "talking with friends",
-        "cheering, celebration",
-    ],
-    "commuting": [
-        "holding bag, walking",
-        "standing, waiting",
-        "looking out window, daydreaming",
-        "wearing earbuds, commuting",
-        "holding coffee, on the go",
-    ],
-    "hobby": [
-        "holding camera, taking photos",
-        "playing instrument",
-        "crafting, creative",
-        "painting, artistic",
-        "playing video games",
-    ],
-    "self_care": [
-        "applying makeup, mirror",
-        "brushing hair",
-        "holding mirror, checking",
-        "skincare routine",
-        "face mask, relaxing",
-    ],
-    "other": [
-        "standing, casual pose",
-        "sitting, relaxed",
-        "casual pose, natural",
-        "looking at camera",
-        "peace sign, friendly",
-    ],
+# ==================== 确定性映射（手动自拍 + LLM 兜底） ====================
+
+# 活动类型到动作的映射（每种类型一个固定值）
+ACTIVITY_ACTIONS: Dict[str, str] = {
+    "sleeping": "lying down, hugging pillow, cozy",
+    "waking_up": "stretching, yawning, messy hair",
+    "eating": "holding chopsticks, eating",
+    "working": "typing on laptop, focused",
+    "studying": "holding book, reading",
+    "exercising": "stretching, athletic, holding water bottle",
+    "relaxing": "lying on couch, relaxed, listening to music",
+    "socializing": "making peace sign, happy, laughing",
+    "commuting": "holding bag, walking, wearing earbuds",
+    "hobby": "holding camera, creative",
+    "self_care": "applying makeup, mirror",
+    "other": "standing, casual pose, natural",
 }
 
 # 活动类型到场景环境的映射
-ACTIVITY_ENVIRONMENTS: Dict[str, List[str]] = {
-    "sleeping": ["bedroom, dim lighting, cozy atmosphere, bed"],
-    "waking_up": ["bedroom, morning light, curtains, warm sunlight"],
-    "eating": ["dining room, table setting", "cafe, cozy interior", "kitchen, home cooking"],
-    "working": ["office desk, computer screen", "study room, books", "coworking space"],
-    "studying": ["library, bookshelves", "study room, desk lamp", "classroom"],
-    "exercising": ["gym, fitness equipment", "outdoor park, morning", "yoga studio"],
-    "relaxing": ["living room, sofa", "balcony, afternoon sun", "garden, natural"],
-    "socializing": ["outdoor cafe", "park bench", "restaurant interior"],
-    "commuting": ["city street, urban", "bus stop", "train station platform"],
-    "hobby": ["art studio", "music room", "craft table"],
-    "self_care": ["bathroom, mirror, vanity", "bedroom vanity table"],
-    "other": ["indoor, natural lighting", "outdoor, casual setting"],
+ACTIVITY_ENVIRONMENTS: Dict[str, str] = {
+    "sleeping": "bedroom, dim lighting, cozy atmosphere, bed",
+    "waking_up": "bedroom, morning light, curtains, warm sunlight",
+    "eating": "dining room, table setting",
+    "working": "office desk, computer screen",
+    "studying": "library, bookshelves, desk lamp",
+    "exercising": "gym, fitness equipment",
+    "relaxing": "living room, sofa, afternoon sun",
+    "socializing": "outdoor cafe, bright atmosphere",
+    "commuting": "city street, urban",
+    "hobby": "art studio, creative space",
+    "self_care": "bathroom, mirror, vanity",
+    "other": "indoor, natural lighting",
 }
 
 # 活动类型到表情的映射
-ACTIVITY_EXPRESSIONS: Dict[str, List[str]] = {
-    "sleeping": ["peaceful expression, closed eyes", "sleepy smile"],
-    "waking_up": ["drowsy expression, half-open eyes", "yawning, cute"],
-    "eating": ["happy expression, enjoying food", "satisfied smile"],
-    "working": ["focused expression, serious", "determined look, concentrated"],
-    "studying": ["focused, reading", "thoughtful expression"],
-    "exercising": ["energetic expression", "sweating, determined", "refreshed smile"],
-    "relaxing": ["relaxed smile, content", "lazy expression, comfortable"],
-    "socializing": ["bright smile, happy", "laughing, cheerful"],
-    "commuting": ["calm expression", "looking forward, determined"],
-    "hobby": ["excited, passionate", "focused, creative"],
-    "self_care": ["gentle smile, self-care", "focused, beauty routine"],
-    "other": ["natural smile", "casual expression"],
+ACTIVITY_EXPRESSIONS: Dict[str, str] = {
+    "sleeping": "peaceful expression, closed eyes",
+    "waking_up": "drowsy expression, half-open eyes",
+    "eating": "happy expression, enjoying food",
+    "working": "focused expression, serious",
+    "studying": "focused, thoughtful expression",
+    "exercising": "energetic expression, determined",
+    "relaxing": "relaxed smile, content",
+    "socializing": "bright smile, happy",
+    "commuting": "calm expression",
+    "hobby": "excited, passionate",
+    "self_care": "gentle smile, self-care",
+    "other": "natural smile",
 }
 
 # 活动类型到光线的映射
-ACTIVITY_LIGHTING: Dict[str, List[str]] = {
-    "sleeping": ["dim warm light, night lamp"],
-    "waking_up": ["soft morning light, golden hour"],
-    "eating": ["warm indoor lighting", "natural window light"],
-    "working": ["office lighting, even illumination"],
-    "studying": ["desk lamp, focused light"],
-    "exercising": ["bright natural light", "gym lighting"],
-    "relaxing": ["soft afternoon light", "warm ambient light"],
-    "socializing": ["bright cheerful lighting", "outdoor natural light"],
-    "commuting": ["urban city lights", "morning sunlight"],
-    "hobby": ["creative studio lighting", "natural side lighting"],
-    "self_care": ["bathroom lighting, mirror reflection"],
-    "other": ["natural lighting"],
+ACTIVITY_LIGHTING: Dict[str, str] = {
+    "sleeping": "dim warm light, night lamp",
+    "waking_up": "soft morning light, golden hour",
+    "eating": "warm indoor lighting",
+    "working": "office lighting, even illumination",
+    "studying": "desk lamp, focused light",
+    "exercising": "bright natural light",
+    "relaxing": "soft afternoon light, warm ambient light",
+    "socializing": "bright cheerful lighting",
+    "commuting": "morning sunlight",
+    "hobby": "creative studio lighting",
+    "self_care": "bathroom lighting, mirror reflection",
+    "other": "natural lighting",
 }
 
 
+# ==================== LLM 场景生成（自动自拍专用） ====================
+
+_SCENE_LLM_PROMPT = """You are a selfie scene tag generator for anime image generation (Stable Diffusion).
+Given a character's current activity description, output a JSON object with 4 keys:
+- action: physical pose/gesture/hand position (3-8 English tags)
+- environment: background and surroundings (3-8 English tags)
+- expression: facial expression (2-5 English tags)
+- lighting: light conditions (2-4 English tags)
+
+Rules:
+1. Output ONLY valid JSON, no markdown, no explanations
+2. All values must be English tags suitable for Stable Diffusion
+3. Do NOT include character appearance (hair, eyes, clothing)
+4. Tags should feel natural for a selfie scenario
+5. Keep tags concise and descriptive
+
+Examples:
+
+Activity: 在书房看轻小说
+{"action": "holding book, reading, relaxed pose", "environment": "study room, bookshelf, warm interior", "expression": "content smile, absorbed", "lighting": "desk lamp, warm indoor light"}
+
+Activity: 在厨房做早饭
+{"action": "holding spatula, cooking", "environment": "kitchen, stove, morning atmosphere", "expression": "happy smile, focused on cooking", "lighting": "morning light through window, bright kitchen"}
+
+Activity: 在公园散步
+{"action": "walking, casual stroll", "environment": "park, trees, pathway, flowers", "expression": "peaceful smile, relaxed", "lighting": "soft natural sunlight, dappled light"}
+
+Now generate for the following activity:"""
+
+
+async def generate_scene_with_llm(activity_info: ActivityInfo) -> Optional[Dict[str, str]]:
+    """使用 LLM 根据活动描述生成英文 SD 场景标签
+
+    Args:
+        activity_info: 活动信息
+
+    Returns:
+        包含 action, environment, expression, lighting 的字典，失败返回 None
+    """
+    try:
+        from src.plugin_system.apis import llm_api
+
+        models = llm_api.get_available_models()
+        model = models.get("replyer")
+        if not model:
+            logger.warning("未找到 replyer 模型，LLM 场景生成失败")
+            return None
+
+        prompt = f"{_SCENE_LLM_PROMPT}\n\nActivity: {activity_info.description}"
+
+        success, response, _, model_name = await llm_api.generate_with_model(
+            prompt=prompt,
+            model_config=model,
+            request_type="plugin.auto_selfie_scene",
+            temperature=0.7,
+            max_tokens=300,
+        )
+
+        if not success or not response:
+            logger.warning("LLM 场景生成返回空响应")
+            return None
+
+        # 清理响应（移除可能的 markdown 代码块）
+        cleaned = response.strip()
+        if cleaned.startswith("```"):
+            cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+            cleaned = re.sub(r"\s*```$", "", cleaned)
+
+        scene = json.loads(cleaned)
+
+        # 验证必要字段
+        required_keys = {"action", "environment", "expression", "lighting"}
+        if not required_keys.issubset(scene.keys()):
+            missing = required_keys - set(scene.keys())
+            logger.warning(f"LLM 场景缺少字段: {missing}")
+            return None
+
+        # 确保所有值都是字符串
+        for key in required_keys:
+            if not isinstance(scene[key], str) or not scene[key].strip():
+                logger.warning(f"LLM 场景字段 {key} 无效: {scene.get(key)}")
+                return None
+
+        logger.info(f"LLM 场景生成成功 (模型: {model_name}): action={scene['action'][:50]}")
+        return {
+            "hand_action": scene["action"],
+            "environment": scene["environment"],
+            "expression": scene["expression"],
+            "lighting": scene["lighting"],
+        }
+
+    except json.JSONDecodeError as e:
+        logger.warning(f"LLM 场景 JSON 解析失败: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"LLM 场景生成异常: {e}")
+        return None
+
+
+# ==================== 公共函数 ====================
+
 def get_action_for_activity(activity_info: ActivityInfo) -> Dict[str, str]:
     """
-    根据活动信息获取适合的动作
+    根据活动类型获取确定性场景数据（手动自拍使用）
 
     Args:
         activity_info: 活动信息
@@ -168,34 +199,23 @@ def get_action_for_activity(activity_info: ActivityInfo) -> Dict[str, str]:
     """
     activity_key = activity_info.activity_type.value
 
-    hand_action = random.choice(
-        ACTIVITY_ACTIONS.get(activity_key, ACTIVITY_ACTIONS["other"])
-    )
-    environment = random.choice(
-        ACTIVITY_ENVIRONMENTS.get(activity_key, ACTIVITY_ENVIRONMENTS["other"])
-    )
-    expression = random.choice(
-        ACTIVITY_EXPRESSIONS.get(activity_key, ACTIVITY_EXPRESSIONS["other"])
-    )
-    lighting = random.choice(
-        ACTIVITY_LIGHTING.get(activity_key, ACTIVITY_LIGHTING["other"])
-    )
-
     return {
-        "hand_action": hand_action,
-        "environment": environment,
-        "expression": expression,
-        "lighting": lighting,
+        "hand_action": ACTIVITY_ACTIONS.get(activity_key, ACTIVITY_ACTIONS["other"]),
+        "environment": ACTIVITY_ENVIRONMENTS.get(activity_key, ACTIVITY_ENVIRONMENTS["other"]),
+        "expression": ACTIVITY_EXPRESSIONS.get(activity_key, ACTIVITY_EXPRESSIONS["other"]),
+        "lighting": ACTIVITY_LIGHTING.get(activity_key, ACTIVITY_LIGHTING["other"]),
     }
 
 
-def convert_to_selfie_prompt(
+async def convert_to_selfie_prompt(
     activity_info: ActivityInfo,
     selfie_style: str = "standard",
     bot_appearance: str = "",
-) -> str:
+) -> Optional[str]:
     """
-    将活动信息转换为完整的自拍 SD 提示词
+    将活动信息转换为完整的自拍 SD 提示词（自动自拍专用）
+
+    使用 LLM 根据活动描述生成场景标签，LLM 失败时返回 None。
 
     Args:
         activity_info: 活动信息
@@ -203,8 +223,14 @@ def convert_to_selfie_prompt(
         bot_appearance: Bot 外观描述（从配置读取的 selfie.prompt_prefix）
 
     Returns:
-        完整的 SD 提示词
+        完整的 SD 提示词，LLM 失败时返回 None
     """
+    # 使用 LLM 生成场景
+    scene = await generate_scene_with_llm(activity_info)
+    if not scene:
+        logger.warning("LLM 场景生成失败，取消本次自拍提示词生成")
+        return None
+
     prompt_parts: List[str] = []
 
     # 1. 强制主体
@@ -214,13 +240,10 @@ def convert_to_selfie_prompt(
     if bot_appearance:
         prompt_parts.append(bot_appearance)
 
-    # 3. 获取场景动作
-    scene = get_action_for_activity(activity_info)
-
-    # 4. 表情
+    # 3. 表情
     prompt_parts.append(f"({scene['expression']}:1.2)")
 
-    # 5. 手部/身体动作
+    # 4. 手部/身体动作
     hand_action = scene["hand_action"]
 
     # standard 自拍禁止手机类词汇
@@ -239,13 +262,13 @@ def convert_to_selfie_prompt(
             hand_prompt = f"({hand_action}:1.3)"
         prompt_parts.append(hand_prompt)
 
-    # 6. 环境
+    # 5. 环境
     prompt_parts.append(scene["environment"])
 
-    # 7. 光线
+    # 6. 光线
     prompt_parts.append(scene["lighting"])
 
-    # 8. 自拍风格
+    # 7. 自拍风格
     if selfie_style == "mirror":
         selfie_scene = (
             "mirror selfie, reflection in mirror, "
@@ -262,7 +285,7 @@ def convert_to_selfie_prompt(
         )
     prompt_parts.append(selfie_scene)
 
-    # 9. 过滤空值、去重、拼接
+    # 8. 过滤空值、去重、拼接
     prompt_parts = [p for p in prompt_parts if p and p.strip()]
     keywords = [kw.strip() for kw in ", ".join(prompt_parts).split(",")]
     seen = set()

--- a/core/selfie/schedule_provider.py
+++ b/core/selfie/schedule_provider.py
@@ -156,6 +156,7 @@ class PlanningPluginProvider(ScheduleProvider):
 
         # 类型映射（覆盖 autonomous_planning 常用的 goal_type 值）
         type_map = {
+            # 英文关键词
             "work": ActivityType.WORKING,
             "study": ActivityType.STUDYING,
             "exercise": ActivityType.EXERCISING,
@@ -168,6 +169,43 @@ class PlanningPluginProvider(ScheduleProvider):
             "sleep": ActivityType.SLEEPING,
             "self_care": ActivityType.SELF_CARE,
             "commut": ActivityType.COMMUTING,
+            # 中文关键词
+            "工作": ActivityType.WORKING,
+            "办公": ActivityType.WORKING,
+            "会议": ActivityType.WORKING,
+            "学习": ActivityType.STUDYING,
+            "阅读": ActivityType.STUDYING,
+            "读书": ActivityType.STUDYING,
+            "审阅": ActivityType.STUDYING,
+            "看书": ActivityType.STUDYING,
+            "研究": ActivityType.STUDYING,
+            "运动": ActivityType.EXERCISING,
+            "锻炼": ActivityType.EXERCISING,
+            "健身": ActivityType.EXERCISING,
+            "散步": ActivityType.EXERCISING,
+            "吃": ActivityType.EATING,
+            "餐": ActivityType.EATING,
+            "料理": ActivityType.EATING,
+            "烹饪": ActivityType.EATING,
+            "休息": ActivityType.RELAXING,
+            "放松": ActivityType.RELAXING,
+            "泡澡": ActivityType.RELAXING,
+            "泡浴": ActivityType.RELAXING,
+            "聊天": ActivityType.SOCIALIZING,
+            "交流": ActivityType.SOCIALIZING,
+            "社交": ActivityType.SOCIALIZING,
+            "睡": ActivityType.SLEEPING,
+            "梦": ActivityType.SLEEPING,
+            "入眠": ActivityType.SLEEPING,
+            "午休": ActivityType.SLEEPING,
+            "小憩": ActivityType.SLEEPING,
+            "梳妆": ActivityType.SELF_CARE,
+            "打扮": ActivityType.SELF_CARE,
+            "化妆": ActivityType.SELF_CARE,
+            "护肤": ActivityType.SELF_CARE,
+            "通勤": ActivityType.COMMUTING,
+            "赶路": ActivityType.COMMUTING,
+            "出行": ActivityType.COMMUTING,
         }
         activity_type = ActivityType.OTHER
         for key, atype in type_map.items():

--- a/core/utils/image_utils.py
+++ b/core/utils/image_utils.py
@@ -137,7 +137,7 @@ class ImageProcessor:
                 if proxy_url:
                     import requests
                     logger.info(f"{self.log_prefix} (B64) 下载HTTP图片 (proxy: {proxy_url})")
-                    resp = requests.get(image_url, timeout=600, proxies={"http": proxy_url, "https": proxy_url})
+                    resp = requests.get(image_url, timeout=180, proxies={"http": proxy_url, "https": proxy_url})
                     if resp.status_code == 200:
                         base64_encoded_image = base64.b64encode(resp.content).decode("utf-8")
                         logger.info(f"{self.log_prefix} (B64) 图片下载编码完成. Base64长度: {len(base64_encoded_image)}")
@@ -148,7 +148,7 @@ class ImageProcessor:
                         return False, error_msg
                 else:
                     logger.info(f"{self.log_prefix} (B64) 下载HTTP图片")
-                    with urllib.request.urlopen(image_url, timeout=600) as response:
+                    with urllib.request.urlopen(image_url, timeout=180) as response:
                         if response.status == 200:
                             image_bytes = response.read()
                             base64_encoded_image = base64.b64encode(image_bytes).decode("utf-8")

--- a/core/utils/runtime_state.py
+++ b/core/utils/runtime_state.py
@@ -5,12 +5,19 @@
 - 模型开关
 - 撤回开关
 - 默认模型设置
+- 自动清理长时间不活跃的聊天流状态
 """
+import time
 from typing import Dict, Any, Optional, Set
 from dataclasses import dataclass, field
 from src.common.logger import get_logger
 
 logger = get_logger("mais_art.state")
+
+# 聊天流状态在无访问后保留的最大时长（秒），默认 24 小时
+_STATE_TTL_SECONDS = 24 * 60 * 60
+# 每次清理扫描的间隔（秒），避免频繁遍历
+_CLEANUP_INTERVAL_SECONDS = 30 * 60
 
 
 @dataclass
@@ -26,6 +33,10 @@ class ChatStreamState:
     action_default_model: Optional[str] = None
     # Command组件默认模型（None表示使用全局配置）
     command_default_model: Optional[str] = None
+    # 自拍日程增强是否启用（None表示使用全局配置）
+    selfie_schedule_enabled: Optional[bool] = None
+    # 最后访问时间戳
+    last_access: float = field(default_factory=time.time)
 
 
 class RuntimeStateManager:
@@ -40,13 +51,44 @@ class RuntimeStateManager:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._states: Dict[str, ChatStreamState] = {}
+            cls._instance._last_cleanup: float = time.time()
         return cls._instance
 
     def _get_state(self, chat_id: str) -> ChatStreamState:
         """获取或创建聊天流状态"""
         if chat_id not in self._states:
             self._states[chat_id] = ChatStreamState()
-        return self._states[chat_id]
+        state = self._states[chat_id]
+        state.last_access = time.time()
+        self._maybe_cleanup()
+        return state
+
+    def _maybe_cleanup(self):
+        """定期清理长时间不活跃的聊天流状态"""
+        now = time.time()
+        if now - self._last_cleanup < _CLEANUP_INTERVAL_SECONDS:
+            return
+        self._last_cleanup = now
+        expired = [
+            cid for cid, s in self._states.items()
+            if now - s.last_access > _STATE_TTL_SECONDS and not self._has_custom_settings(s)
+        ]
+        for cid in expired:
+            del self._states[cid]
+        if expired:
+            logger.debug(f"[RuntimeState] 清理了 {len(expired)} 个不活跃的聊天流状态")
+
+    @staticmethod
+    def _has_custom_settings(state: ChatStreamState) -> bool:
+        """检查聊天流是否有用户手动设置的自定义配置（有则不清理）"""
+        return (
+            state.plugin_enabled is not None
+            or state.disabled_models
+            or state.recall_disabled_models
+            or state.action_default_model is not None
+            or state.command_default_model is not None
+            or state.selfie_schedule_enabled is not None
+        )
 
     # ==================== 插件开关 ====================
 
@@ -172,6 +214,35 @@ class RuntimeStateManager:
         state.command_default_model = None
         logger.info(f"[RuntimeState] 聊天流 {chat_id} Command默认模型已重置为全局配置")
 
+    # ==================== 自拍日程开关 ====================
+
+    def is_selfie_schedule_enabled(self, chat_id: str, global_enabled: bool) -> bool:
+        """检查自拍日程增强是否启用
+
+        Args:
+            chat_id: 聊天流ID
+            global_enabled: 全局配置的启用状态
+
+        Returns:
+            是否启用（优先使用聊天流状态，否则使用全局配置）
+        """
+        state = self._get_state(chat_id)
+        if state.selfie_schedule_enabled is not None:
+            return state.selfie_schedule_enabled
+        return global_enabled
+
+    def set_selfie_schedule_enabled(self, chat_id: str, enabled: bool) -> None:
+        """设置自拍日程增强启用状态"""
+        state = self._get_state(chat_id)
+        state.selfie_schedule_enabled = enabled
+        logger.info(f"[RuntimeState] 聊天流 {chat_id} 自拍日程增强设置为: {enabled}")
+
+    def reset_selfie_schedule_enabled(self, chat_id: str) -> None:
+        """重置自拍日程增强为全局配置"""
+        state = self._get_state(chat_id)
+        state.selfie_schedule_enabled = None
+        logger.info(f"[RuntimeState] 聊天流 {chat_id} 自拍日程增强已重置为全局配置")
+
     # ==================== 状态重置 ====================
 
     def reset_chat_state(self, chat_id: str) -> None:
@@ -189,6 +260,7 @@ class RuntimeStateManager:
             "recall_disabled_models": list(state.recall_disabled_models),
             "action_default_model": state.action_default_model,
             "command_default_model": state.command_default_model,
+            "selfie_schedule_enabled": state.selfie_schedule_enabled,
         }
 
 


### PR DESCRIPTION
- 手动自拍日程可选：新增 /dr selfie on|off 按聊天流控制日程增强开关
- RuntimeState 新增 selfie_schedule_enabled 字段，config_schema 新增 selfie.schedule_enabled
- 自动自拍改用 LLM 根据日程活动描述生成英文 SD 场景标签，替代 12 类随机组合
- scene_action_generator 确定性映射保留供手动自拍使用，新增 async generate_scene_with_llm
- convert_to_selfie_prompt 改为 async，LLM 失败返回 None 直接取消
- generate_image_standalone 新增 strength 参数并透传至 client
- 自动自拍传入 model default_size 替代硬编码 1024x1024
- _resolve_image_to_bytes 改为 async httpx.AsyncClient
- 帮助页单一入口，管理员/非管理员条件显示，新增 /dr style 命令
- 清理未使用导入：datetime、asyncio、ActivityInfo、BASE64_IMAGE_PREFIXES
- 更新 README 反映日程增强、LLM 生成、参考图支持等变更