### PR TITLE
feat: 自拍手部质量优化 + 三风格体系 + LLM 动作生成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.log
 
 # 忽略特定目录
-old/*
+old/
 __pycache__/
 .claude
 test/*

--- a/core/api_clients/openai_chat_client.py
+++ b/core/api_clients/openai_chat_client.py
@@ -82,7 +82,7 @@ class OpenAIChatClient(BaseApiClient):
 
         # 添加可选的生成参数
         seed = model_config.get("seed", -1)
-        if seed and seed != -1:
+        if seed is not None and seed != -1:
             payload_dict["seed"] = seed
 
         # 某些模型支持 size 参数

--- a/core/api_clients/openai_client.py
+++ b/core/api_clients/openai_client.py
@@ -52,7 +52,7 @@ class OpenAIClient(BaseApiClient):
         # 添加可选参数
         if negative_prompt:
             payload_dict["negative_prompt"] = negative_prompt
-        if seed and seed != -1:
+        if seed is not None and seed != -1:
             payload_dict["seed"] = seed
 
         # 如果有输入图片，添加图生图参数

--- a/core/selfie/auto_selfie_task.py
+++ b/core/selfie/auto_selfie_task.py
@@ -127,7 +127,7 @@ class AutoSelfieTask:
         logger.info(f"当前活动: {activity.description} ({activity.activity_type.value})")
 
         # 2. 生成自拍提示词
-        selfie_style = self.get_config("auto_selfie.selfie_style", "standard")
+        selfie_style = self.get_config("selfie.default_style", "standard")
         bot_appearance = self.get_config("selfie.prompt_prefix", "")
         prompt = await convert_to_selfie_prompt(activity, selfie_style, bot_appearance)
         if not prompt:

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,6 +1,6 @@
 """工具函数统一入口"""
 
-from .shared_constants import BASE64_IMAGE_PREFIXES, ANTI_DUAL_HANDS_PROMPT
+from .shared_constants import BASE64_IMAGE_PREFIXES, ANTI_DUAL_HANDS_PROMPT, SELFIE_HAND_NEGATIVE, ANTI_DUAL_PHONE_PROMPT
 from .model_utils import get_model_config, merge_negative_prompt, inject_llm_original_size
 from .image_utils import ImageProcessor
 from .image_send_utils import resolve_image_data

--- a/core/utils/shared_constants.py
+++ b/core/utils/shared_constants.py
@@ -4,12 +4,24 @@
 # JPEG: /9j/  PNG: iVBORw  WEBP: UklGR  GIF: R0lGOD
 BASE64_IMAGE_PREFIXES = ("iVBORw", "/9j/", "UklGR", "R0lGOD")
 
-# 防止生成双手拿手机等不自然姿态的负面提示词
-ANTI_DUAL_HANDS_PROMPT = (
+# 自拍通用手部质量负面提示词（所有自拍风格共用）
+SELFIE_HAND_NEGATIVE = (
+    "extra fingers, missing fingers, fused fingers, too many fingers, "
+    "mutated hands, malformed hands, bad hands, wrong hands, "
+    "extra hands, extra arms, 3 hands, 4 hands, multiple hands, "
+    "deformed fingers, interlocked fingers, twisted fingers, "
+    "six fingers, more than 5 fingers, fewer than 5 fingers, "
+    "extra digit, missing digit, bad anatomy"
+)
+
+# 标准自拍专用：防止生成双手拿手机等不自然姿态
+ANTI_DUAL_PHONE_PROMPT = (
     "two phones, camera in both hands, "
     "holding phone with both hands, "
-    "extra hands, extra arms, 3 hands, 4 hands, "
-    "multiple hands, both hands holding phone, "
+    "both hands holding phone, "
     "phone in frame, visible phone in hand, "
     "both hands visible"
 )
+
+# 向后兼容别名
+ANTI_DUAL_HANDS_PROMPT = f"{SELFIE_HAND_NEGATIVE}, {ANTI_DUAL_PHONE_PROMPT}"

--- a/plugin.py
+++ b/plugin.py
@@ -363,7 +363,7 @@ class MaisArtJournalPlugin(BasePlugin):
             "negative_prompt": ConfigField(
                 type=str,
                 default="",
-                description="自拍模式基础负面提示词。自动附加 anti-dual-hands 提示词（防止双手拿手机等不自然姿态）。此处可添加额外的负面提示词",
+                description="自拍模式基础负面提示词。所有风格自动附加手部质量负面提示词，standard 风格额外附加防双手拿手机提示词。此处可添加额外的负面提示词",
                 label="负面提示词",
                 input_type="textarea",
                 rows=3,
@@ -380,6 +380,16 @@ class MaisArtJournalPlugin(BasePlugin):
                 depends_on="selfie.enabled",
                 depends_value=True,
                 order=5
+            ),
+            "default_style": ConfigField(
+                type=str,
+                default="standard",
+                description="自拍默认风格（手动和自动自拍共用）：standard(前置自拍)/mirror(对镜自拍)/photo(第三人称照片)。可通过 /dr selfie standard|mirror|photo 按聊天流覆盖",
+                label="默认自拍风格",
+                choices=["standard", "mirror", "photo"],
+                depends_on="selfie.enabled",
+                depends_value=True,
+                order=6
             )
         },
         "auto_recall": {
@@ -429,16 +439,6 @@ class MaisArtJournalPlugin(BasePlugin):
                 depends_value=True,
                 order=3
             ),
-            "selfie_style": ConfigField(
-                type=str,
-                default="standard",
-                description="自拍风格：standard(前置自拍)/mirror(对镜自拍)",
-                label="自拍风格",
-                choices=["standard", "mirror"],
-                depends_on="auto_selfie.enabled",
-                depends_value=True,
-                order=4
-            ),
             "quiet_hours_start": ConfigField(
                 type=str,
                 default="00:00",
@@ -448,7 +448,7 @@ class MaisArtJournalPlugin(BasePlugin):
                 placeholder="00:00",
                 depends_on="auto_selfie.enabled",
                 depends_value=True,
-                order=5
+                order=4
             ),
             "quiet_hours_end": ConfigField(
                 type=str,
@@ -458,7 +458,7 @@ class MaisArtJournalPlugin(BasePlugin):
                 placeholder="07:00",
                 depends_on="auto_selfie.enabled",
                 depends_value=True,
-                order=6
+                order=5
             ),
             "caption_enabled": ConfigField(
                 type=bool,
@@ -467,7 +467,7 @@ class MaisArtJournalPlugin(BasePlugin):
                 label="生成配文",
                 depends_on="auto_selfie.enabled",
                 depends_value=True,
-                order=7
+                order=6
             ),
         },
         "models": {},


### PR DESCRIPTION
- 拆分负面提示词为 SELFIE_HAND_NEGATIVE（通用手部质量）和 ANTI_DUAL_PHONE_PROMPT（standard 专用防双手拿手机），所有风格统一附加手部质量负面
- 新增 photo（第三人称照片）自拍风格，现支持 standard/mirror/photo 三种风格
- 为每种风格创建物理约束一致的专属手部动作池（standard 23/mirror 20/photo 25 个动作）
- LLM 场景生成 prompt 增加风格约束规则（_SCENE_STYLE_HINTS），自动适配单手/双手物理限制
- 手动自拍新增 LLM 手部动作生成（generate_hand_action_with_llm），复用自动自拍同一套 prompt，动作池仅作兜底
- 正面提示词统一添加 (perfect hands:1.2), (correct anatomy:1.1) 手部质量引导
- 新增 selfie.default_style 配置项（手动和自动自拍共用），支持 /dr selfie standard|mirror|photo 按聊天流覆盖
- 修复 pic_action.py 中 self.plugin AttributeError（改用 plugin_manager.get_plugin_instance）
- 移除废弃的 auto_selfie.selfie_style 配置项，修复 auto_selfie order 跳号
- 更新 README 和配置项说明