### PR TITLE
fix: 修正 manifest categories 为预定义分类标识符

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -21,8 +21,8 @@
     "image"
   ],
   "categories": [
-    "Expression",
-    "Picture"
+    "Content Generation",
+    "Multimedia"
   ],
   "default_locale": "zh-CN",
   "locales_path": "_locales",


### PR DESCRIPTION
fix: 修正 manifest categories 为预定义分类标识符