### PR TITLE
fix: 阻止 /dr 命令被群内别的 bot 帮助文本误触发 (v4.0.1)

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "name": "麦麦绘卷（Claude MAInet）",
   "description": "基于 MaiBot 的多模型智能绘图插件。兼容 OpenAI、OpenAI-Chat、豆包（火山方舟）、Gemini、魔搭、硅基流动、砂糖云、梦羽、智谱 GLM、阿里百炼 DashScope（通义千问/万相/Z-Image/可灵）、ComfyUI 等多种 API 格式。提供命令式风格转换、自拍模式、自动自拍发说说、日程感知、模型配置管理、运行时聊天流隔离状态、对外 @API 生图接口等功能。",
   "author": {

--- a/core/commands/dispatcher.py
+++ b/core/commands/dispatcher.py
@@ -36,6 +36,7 @@ class DispatcherContext:
     message: Any
     is_admin: bool
     log_prefix: str
+    prefix: str = "/dr"
     user_id: str = ""
     group_id: str = ""
     user_nickname: str = ""
@@ -69,6 +70,7 @@ class CommandDispatcher:
             message=message,
             is_admin=self._is_admin(user_id),
             log_prefix=self._log_prefix(group_name, user_nickname),
+            prefix=self._resolved_prefix(),
             user_id=user_id,
             group_id=group_id,
             user_nickname=user_nickname,
@@ -106,6 +108,16 @@ class CommandDispatcher:
 
     # ==================== 上下文辅助 ====================
 
+    def _resolved_prefix(self) -> str:
+        """读取 basic.command_prefix，统一带 / 形式；读取失败回退到 /dr"""
+        try:
+            prefix = (self.plugin.config.basic.command_prefix or "/dr").strip()
+        except Exception:
+            prefix = "/dr"
+        if not prefix.startswith("/"):
+            prefix = "/" + prefix
+        return prefix
+
     def _is_admin(self, user_id: str) -> bool:
         if not user_id:
             return False
@@ -120,8 +132,4 @@ class CommandDispatcher:
             return f"[{group_name}]"
         if user_nickname:
             return f"[{user_nickname} 的 私聊]"
-        try:
-            prefix = (self.plugin.config.basic.command_prefix or "/dr").strip()
-            return f"[MaisArt {prefix}]"
-        except Exception:
-            return "[MaisArt]"
+        return f"[MaisArt {self._resolved_prefix()}]"

--- a/core/commands/generate.py
+++ b/core/commands/generate.py
@@ -56,7 +56,8 @@ async def handle_generate(plugin: "MaisArtPlugin", dctx: "DispatcherContext", co
     """fallback 入口：先尝试风格，否则按自然语言"""
     if not content:
         await plugin.ctx.send.text(
-            "请指定风格或描述，格式：/dr <风格> 或 /dr <描述>\n可用：/dr styles 查看风格列表",
+            f"请指定风格或描述，格式：{dctx.prefix} <风格> 或 {dctx.prefix} <描述>\n"
+            f"可用：{dctx.prefix} styles 查看风格列表",
             dctx.stream_id,
         )
         return False, "缺少内容参数", True
@@ -78,7 +79,9 @@ async def handle_generate(plugin: "MaisArtPlugin", dctx: "DispatcherContext", co
         logger.info(f"{dctx.log_prefix} 识别为自然语言模式: {content}")
         return await _execute_natural_mode(plugin, dctx, content)
 
-    await plugin.ctx.send.text(f"风格 '{content}' 不存在，使用 /dr styles 查看所有风格", dctx.stream_id)
+    await plugin.ctx.send.text(
+        f"风格 '{content}' 不存在，使用 {dctx.prefix} styles 查看所有风格", dctx.stream_id,
+    )
     return False, f"风格 '{content}' 不存在", True
 
 

--- a/core/commands/handlers/config_handlers.py
+++ b/core/commands/handlers/config_handlers.py
@@ -50,7 +50,7 @@ async def cmd_list(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: str
             f"• {model_id}{default_mark}{command_mark}{img2img_mark}{disabled_mark}{recall_mark}\n"
             f"  模型: {model_name}\n"
         )
-    lines.append("\n📖 图例：✅默认 🔧/dr命令 🖼️图生图 📝仅文生图")
+    lines.append(f"\n📖 图例：✅默认 🔧{dctx.prefix}命令 🖼️图生图 📝仅文生图")
     await plugin.ctx.send.text("\n".join(lines), dctx.stream_id)
     return True, "模型列表查询成功", True
 
@@ -66,11 +66,13 @@ async def cmd_set(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: str)
     """/dr set <模型ID> — 设置 /dr 命令使用的模型"""
     model_id = args.strip()
     if not model_id:
-        await plugin.ctx.send.text("请指定模型ID，格式：/dr set <模型ID>", dctx.stream_id)
+        await plugin.ctx.send.text(f"请指定模型ID，格式：{dctx.prefix} set <模型ID>", dctx.stream_id)
         return False, "缺少模型ID参数", True
 
     if not model_exists(plugin, model_id):
-        await plugin.ctx.send.text(f"模型 '{model_id}' 不存在，请使用 /dr list 查看可用模型", dctx.stream_id)
+        await plugin.ctx.send.text(
+            f"模型 '{model_id}' 不存在，请使用 {dctx.prefix} list 查看可用模型", dctx.stream_id,
+        )
         return False, f"模型 '{model_id}' 不存在", True
 
     if not runtime_state.is_model_enabled(dctx.chat_id, model_id):
@@ -87,7 +89,7 @@ async def cmd_default(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: 
     """/dr default <模型ID> — 设置 Action 组件默认模型"""
     model_id = args.strip()
     if not model_id:
-        await plugin.ctx.send.text("格式：/dr default <模型ID>", dctx.stream_id)
+        await plugin.ctx.send.text(f"格式：{dctx.prefix} default <模型ID>", dctx.stream_id)
         return False, "缺少模型ID", True
 
     if not model_exists(plugin, model_id):
@@ -113,10 +115,10 @@ async def cmd_reset(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: st
     await plugin.ctx.send.text(
         f"✅ 当前聊天流配置已重置！\n\n"
         f"🎯 默认模型: {global_action_model}\n"
-        f"🔧 /dr命令模型: {global_command_model}\n"
+        f"🔧 {dctx.prefix}命令模型: {global_command_model}\n"
         f"📋 所有模型已启用\n"
         f"🔔 所有撤回已启用\n\n"
-        f"使用 /dr config 查看当前配置",
+        f"使用 {dctx.prefix} config 查看当前配置",
         dctx.stream_id,
     )
     logger.info(f"聊天流 {dctx.chat_id} 配置已重置")

--- a/core/commands/handlers/selfie_handlers.py
+++ b/core/commands/handlers/selfie_handlers.py
@@ -36,7 +36,8 @@ async def cmd_selfie(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: s
         return True, f"自拍风格切换为{action}", True
 
     await plugin.ctx.send.text(
-        "格式：/dr selfie on|off（日程增强）或 /dr selfie standard|mirror|photo（自拍风格）",
+        f"格式：{dctx.prefix} selfie on|off（日程增强）或 "
+        f"{dctx.prefix} selfie standard|mirror|photo（自拍风格）",
         dctx.stream_id,
     )
     return False, "参数无效", True

--- a/core/commands/handlers/style_handlers.py
+++ b/core/commands/handlers/style_handlers.py
@@ -31,7 +31,7 @@ async def cmd_styles(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: s
         alias_list = [a.strip() for a in aliases_raw.split(",") if a.strip()] if aliases_raw else []
         alias_text = f" (别名: {', '.join(alias_list)})" if alias_list else ""
         lines.append(f"• {name}{alias_text}")
-    lines.append("\n💡 使用方法: /dr <风格名>")
+    lines.append(f"\n💡 使用方法: {dctx.prefix} <风格名>")
 
     await plugin.ctx.send.text("\n".join(lines), dctx.stream_id)
     return True, "风格列表查询成功", True
@@ -42,20 +42,20 @@ async def cmd_style(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: st
     """/dr style <风格名> — 显示风格详情"""
     style_name = (args or "").strip()
     if not style_name:
-        await plugin.ctx.send.text("请指定风格名，格式：/dr style <风格名>", dctx.stream_id)
+        await plugin.ctx.send.text(f"请指定风格名，格式：{dctx.prefix} style <风格名>", dctx.stream_id)
         return False, "缺少风格名参数", True
 
     actual = resolve_style_alias(plugin, style_name)
     if not actual:
         await plugin.ctx.send.text(
-            f"风格 '{style_name}' 不存在，请使用 /dr styles 查看可用风格", dctx.stream_id,
+            f"风格 '{style_name}' 不存在，请使用 {dctx.prefix} styles 查看可用风格", dctx.stream_id,
         )
         return False, f"风格 '{style_name}' 不存在", True
 
     style_prompt = get_style_prompt(plugin, actual)
     if not style_prompt:
         await plugin.ctx.send.text(
-            f"风格 '{style_name}' 不存在，请使用 /dr styles 查看可用风格", dctx.stream_id,
+            f"风格 '{style_name}' 不存在，请使用 {dctx.prefix} styles 查看可用风格", dctx.stream_id,
         )
         return False, f"风格 '{style_name}' 不存在", True
 
@@ -77,7 +77,7 @@ async def cmd_style(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: st
         lines.append(f"🏷️ 别名: {', '.join(aliases)}\n")
     lines.extend([
         "💡 使用方法：",
-        f"/dr {style_name}",
+        f"{dctx.prefix} {style_name}",
         "\n⚠️ 注意：需要先发送一张图片作为输入",
     ])
     await plugin.ctx.send.text("\n".join(lines), dctx.stream_id)

--- a/core/commands/handlers/toggle_handlers.py
+++ b/core/commands/handlers/toggle_handlers.py
@@ -36,12 +36,12 @@ async def cmd_model(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: st
     """/dr model on|off <模型ID>"""
     parts = args.split(maxsplit=1)
     if len(parts) < 2:
-        await plugin.ctx.send.text("格式：/dr model on|off <模型ID>", dctx.stream_id)
+        await plugin.ctx.send.text(f"格式：{dctx.prefix} model on|off <模型ID>", dctx.stream_id)
         return False, "参数不足", True
 
     action, model_id = parts[0].lower(), parts[1].strip()
     if action not in ("on", "off"):
-        await plugin.ctx.send.text("格式：/dr model on|off <模型ID>", dctx.stream_id)
+        await plugin.ctx.send.text(f"格式：{dctx.prefix} model on|off <模型ID>", dctx.stream_id)
         return False, "无效的操作", True
 
     if not get_model_config(plugin, model_id):
@@ -60,12 +60,12 @@ async def cmd_recall(plugin: "MaisArtPlugin", dctx: "DispatcherContext", args: s
     """/dr recall on|off <模型ID>"""
     parts = args.split(maxsplit=1)
     if len(parts) < 2:
-        await plugin.ctx.send.text("格式：/dr recall on|off <模型ID>", dctx.stream_id)
+        await plugin.ctx.send.text(f"格式：{dctx.prefix} recall on|off <模型ID>", dctx.stream_id)
         return False, "参数不足", True
 
     action, model_id = parts[0].lower(), parts[1].strip()
     if action not in ("on", "off"):
-        await plugin.ctx.send.text("格式：/dr recall on|off <模型ID>", dctx.stream_id)
+        await plugin.ctx.send.text(f"格式：{dctx.prefix} recall on|off <模型ID>", dctx.stream_id)
         return False, "无效的操作", True
 
     if not get_model_config(plugin, model_id):

--- a/core/commands/help_renderer.py
+++ b/core/commands/help_renderer.py
@@ -14,17 +14,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger("plugin.mais_art_journal.help")
 
 
-def _resolved_prefix(dctx: "DispatcherContext") -> str:
-    """读取当前命令前缀（统一带 / 形式）"""
-    prefix = (dctx.plugin.config.basic.command_prefix or "/dr").strip()
-    if not prefix.startswith("/"):
-        prefix = "/" + prefix
-    return prefix
-
-
 async def render_help(dctx: "DispatcherContext") -> CommandResult:
     """渲染 help / 空调用的帮助文案（前缀跟随 basic.command_prefix）"""
-    prefix = _resolved_prefix(dctx)
+    prefix = dctx.prefix
     lines = [
         "🎨 图片风格系统帮助\n",
         "📋 基本命令：",
@@ -62,7 +54,7 @@ async def render_current_config(dctx: "DispatcherContext") -> CommandResult:
     """config：渲染当前聊天流的配置摘要"""
     plugin = dctx.plugin
     chat_id = dctx.chat_id
-    prefix = _resolved_prefix(dctx)
+    prefix = dctx.prefix
 
     global_action_model = plugin.config.basic.default_model
     global_command_model = plugin.config.basic.pic_command_model

--- a/plugin.py
+++ b/plugin.py
@@ -376,7 +376,7 @@ class MaisArtPlugin(MaiBotPlugin):
     @Command(
         "dr",
         description="麦麦绘卷命令套件（生图 / 模型管理 / 风格管理 / 自拍开关）。命令前缀可在「基础配置.命令前缀」修改后重启 MaiBot 生效",
-        pattern=r"(?:.*，说：\s*)?/dr(?:\s+(?P<rest>.+))?$",
+        pattern=r"^(?:.*，说：\s*)?/dr(?:\s+(?P<rest>.+))?$",
     )
     async def handle_dr(self, **kwargs: Any):
         """命令入口：实际 pattern 由 get_components() 按 config.basic.command_prefix 动态注入
@@ -437,7 +437,10 @@ class MaisArtPlugin(MaiBotPlugin):
         if not prefix.startswith("/"):
             prefix = "/" + prefix
         escaped = re.escape(prefix)
-        new_pattern = rf"(?:.*，说：\s*)?{escaped}(?:\s+(?P<rest>.+))?$"
+        # 必须 ^ 锚定起始：MaiBot host 用的是 re.search 而不是 re.match，
+        # 没有 ^ 锚的话，任何文本末尾长得像 "<prefix> xxx" 的消息（包括别的 bot 的
+        # 帮助文本）都会被吃中。
+        new_pattern = rf"^(?:.*，说：\s*)?{escaped}(?:\s+(?P<rest>.+))?$"
 
         for comp in components:
             if (


### PR DESCRIPTION
根因：
- 所有 handler / 帮助文本写死 "/dr"，用户改了 basic.command_prefix 后， 自己的 bot 仍然在群里漏出 "/dr <风格名>" 字样
- 命令 pattern `(?:.*，说：\s*)?/dr(?:\s+(?P<rest>.+))?$` 只有 `$` 没有 `^`， MaiBot host 用 re.search 匹配 → 整段文本只要末尾长得像 "/dr xxx" 就会被吃中，于是默认 /dr 前缀的 bot 把别人帮助文本里的 /dr <风格名> 当成自己的命令来执行

修复：
- DispatcherContext 新增 prefix 字段，由 dispatcher 统一从 basic.command_prefix 解析并注入
- help_renderer / style / generate / config / toggle / selfie handlers 全部改用 dctx.prefix，不再写死 /dr
- plugin.py @Command 默认 pattern + get_components 动态 pattern 都加上 ^ 起始锚点，防止 re.search 在文本中段命中